### PR TITLE
Use reflection to avoid TestNG version collision; no dependency mgmt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,10 +68,12 @@
       <version>${testng.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- required by logback-core test jar -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -90,11 +92,6 @@
       <artifactId>logback-classic</artifactId>
       <version>${logback.version}</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
     </dependency>
   </dependencies>
   

--- a/pom.xml
+++ b/pom.xml
@@ -61,69 +61,40 @@
     </repository>
   </distributionManagement>
   
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.testng</groupId>
-        <artifactId>testng</artifactId>
-        <version>${testng.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-core</artifactId>
-        <version>${logback.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-core</artifactId>
-        <version>${logback.version}</version>
-        <type>test-jar</type>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>${logback.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${guava.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
+      <version>${testng.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <version>${junit.version}</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
+      <version>${logback.version}</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
+      <version>${logback.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
   </dependencies>
   

--- a/src/main/java/com/github/sbabcoc/logback/testng/ReporterAppender.java
+++ b/src/main/java/com/github/sbabcoc/logback/testng/ReporterAppender.java
@@ -5,8 +5,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 
-import com.google.common.base.Joiner;
-
 import ch.qos.logback.core.OutputStreamAppender;
 
 public class ReporterAppender<E> extends OutputStreamAppender<E> {
@@ -61,14 +59,11 @@ public class ReporterAppender<E> extends OutputStreamAppender<E> {
     }
     
 	@Override
-    @SuppressWarnings("unchecked")
     public String toString() {
-    	if (getCurrentTestResult != null) {
-        	Object testResult;
+    	if ((getCurrentTestResult != null) && (getOutput != null)) {
 			try {
-				testResult = getCurrentTestResult.invoke(null);
-	        	List<String> output = (List<String>) getOutput.invoke(null, testResult);
-	        	return Joiner.on("").join(output);
+				Object testResult = getCurrentTestResult.invoke(null);
+	        	return concat(getOutput.invoke(null, testResult));
 			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
 				// nothing to do here
 			}
@@ -111,6 +106,20 @@ public class ReporterAppender<E> extends OutputStreamAppender<E> {
 				// nothing to do here
 			}
     	}
+    }
+    
+    /**
+     * Concatenate the elements of the specified list of strings.
+     * @param parts list of strings to concatenate
+     * @return concatenated string
+     */
+    @SuppressWarnings("unchecked")
+    private static String concat(Object parts) {
+    	StringBuilder builder = new StringBuilder();
+    	for (String part : (List<String>) parts) {
+    		builder.append(part);
+    	}
+        return builder.toString();
     }
 
 }

--- a/src/main/java/com/github/sbabcoc/logback/testng/ReporterAppender.java
+++ b/src/main/java/com/github/sbabcoc/logback/testng/ReporterAppender.java
@@ -1,9 +1,9 @@
 package com.github.sbabcoc.logback.testng;
 
 import java.io.OutputStream;
-
-import org.testng.ITestResult;
-import org.testng.Reporter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
 
 import com.google.common.base.Joiner;
 
@@ -11,7 +11,33 @@ import ch.qos.logback.core.OutputStreamAppender;
 
 public class ReporterAppender<E> extends OutputStreamAppender<E> {
 
+    private static final Method getCurrentTestResult;
+    private static final Method getOutput;
+    private static final Method log;
+    
     protected boolean logToStdOut = false;
+    
+    static {
+    	Method gctr = null;
+    	Method go = null;
+    	Method l = null;
+    	try {
+			Class<?> reporter = Class.forName("org.testng.Reporter");
+			Class<?> testResult = Class.forName("org.testng.ITestResult");
+			
+			gctr = reporter.getMethod("getCurrentTestResult");
+			go = reporter.getMethod("getOutput", testResult);
+			l = reporter.getMethod("log", String.class, Boolean.TYPE);
+		} catch (ClassNotFoundException | NoSuchMethodException | SecurityException e) {
+	    	gctr = null;
+	    	go = null;
+	    	l = null;
+		} finally {
+			getCurrentTestResult = gctr;
+			getOutput = go;
+			log = l;
+		}
+    }
     
     @Override
     public void start() {
@@ -34,10 +60,20 @@ public class ReporterAppender<E> extends OutputStreamAppender<E> {
         throw new UnsupportedOperationException("The output stream of " + this.getClass().getName() + " cannot be altered");
     }
     
-    @Override
+	@Override
+    @SuppressWarnings("unchecked")
     public String toString() {
-        ITestResult testResult = Reporter.getCurrentTestResult();
-        return Joiner.on("").join(Reporter.getOutput(testResult));
+    	if (getCurrentTestResult != null) {
+        	Object testResult;
+			try {
+				testResult = getCurrentTestResult.invoke(null);
+	        	List<String> output = (List<String>) getOutput.invoke(null, testResult);
+	        	return Joiner.on("").join(output);
+			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+				// nothing to do here
+			}
+    	}
+    	return "";
     }
 
     /**
@@ -60,6 +96,21 @@ public class ReporterAppender<E> extends OutputStreamAppender<E> {
      */
     public boolean doLogToStdOut() {
         return logToStdOut;
+    }
+    
+    /**
+     * Log the passed string to the HTML reports. If logToStandardOut is true, the string will also be printed on standard out.
+     * @param s The message to log
+     * @param logToStandardOut Whether to print this string on standard out too
+     */
+    static void log(String s, boolean logToStandardOut) {
+    	if (log != null) {
+    		try {
+				log.invoke(null, s, logToStandardOut);
+			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+				// nothing to do here
+			}
+    	}
     }
 
 }

--- a/src/main/java/com/github/sbabcoc/logback/testng/ReporterAppender.java
+++ b/src/main/java/com/github/sbabcoc/logback/testng/ReporterAppender.java
@@ -12,31 +12,31 @@ public class ReporterAppender<E> extends OutputStreamAppender<E> {
     private static final Method getCurrentTestResult;
     private static final Method getOutput;
     private static final Method log;
-    
+
     protected boolean logToStdOut = false;
-    
+
     static {
-    	Method gctr = null;
-    	Method go = null;
-    	Method l = null;
-    	try {
-			Class<?> reporter = Class.forName("org.testng.Reporter");
-			Class<?> testResult = Class.forName("org.testng.ITestResult");
-			
-			gctr = reporter.getMethod("getCurrentTestResult");
-			go = reporter.getMethod("getOutput", testResult);
-			l = reporter.getMethod("log", String.class, Boolean.TYPE);
-		} catch (ClassNotFoundException | NoSuchMethodException | SecurityException e) {
-	    	gctr = null;
-	    	go = null;
-	    	l = null;
-		} finally {
-			getCurrentTestResult = gctr;
-			getOutput = go;
-			log = l;
-		}
+        Method gctr = null;
+        Method go = null;
+        Method l = null;
+        try {
+            Class<?> reporter = Class.forName("org.testng.Reporter");
+            Class<?> testResult = Class.forName("org.testng.ITestResult");
+            
+            gctr = reporter.getMethod("getCurrentTestResult");
+            go = reporter.getMethod("getOutput", testResult);
+            l = reporter.getMethod("log", String.class, Boolean.TYPE);
+        } catch (ClassNotFoundException | NoSuchMethodException | SecurityException e) {
+            gctr = null;
+            go = null;
+            l = null;
+        } finally {
+            getCurrentTestResult = gctr;
+            getOutput = go;
+            log = l;
+        }
     }
-    
+
     @Override
     public void start() {
         ReporterOutputStream ros = new ReporterOutputStream();
@@ -44,7 +44,7 @@ public class ReporterAppender<E> extends OutputStreamAppender<E> {
         super.setOutputStream(ros);
         super.start();
     }
-    
+
     @Override
     protected void subAppend(E event) {
         if (started) {
@@ -52,23 +52,23 @@ public class ReporterAppender<E> extends OutputStreamAppender<E> {
             ((ReporterOutputStream) getOutputStream()).flush();
         }
     }
-    
+
     @Override
     public void setOutputStream(OutputStream outputStream) {
         throw new UnsupportedOperationException("The output stream of " + this.getClass().getName() + " cannot be altered");
     }
-    
-	@Override
+
+    @Override
     public String toString() {
-    	if ((getCurrentTestResult != null) && (getOutput != null)) {
-			try {
-				Object testResult = getCurrentTestResult.invoke(null);
-	        	return concat(getOutput.invoke(null, testResult));
-			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-				// nothing to do here
-			}
-    	}
-    	return "";
+        if ((getCurrentTestResult != null) && (getOutput != null)) {
+            try {
+                Object testResult = getCurrentTestResult.invoke(null);
+                return concat(getOutput.invoke(null, testResult));
+            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+                // nothing to do here
+            }
+        }
+        return "";
     }
 
     /**
@@ -83,7 +83,7 @@ public class ReporterAppender<E> extends OutputStreamAppender<E> {
             ros.setLogToStdOut(logToStdOut);
         }
     }
-    
+
     /**
      * Determine if output is being forked to <i>STDOUT</i> and the TestNG HTML report.
      * @return {@code false} if output is being sent solely to the TestNG HTML report; 
@@ -92,22 +92,22 @@ public class ReporterAppender<E> extends OutputStreamAppender<E> {
     public boolean doLogToStdOut() {
         return logToStdOut;
     }
-    
+
     /**
      * Log the passed string to the HTML reports. If logToStandardOut is true, the string will also be printed on standard out.
      * @param s The message to log
      * @param logToStandardOut Whether to print this string on standard out too
      */
     static void log(String s, boolean logToStandardOut) {
-    	if (log != null) {
-    		try {
-				log.invoke(null, s, logToStandardOut);
-			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-				// nothing to do here
-			}
-    	}
+        if (log != null) {
+            try {
+                log.invoke(null, s, logToStandardOut);
+            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+                // nothing to do here
+            }
+        }
     }
-    
+
     /**
      * Concatenate the elements of the specified list of strings.
      * @param parts list of strings to concatenate
@@ -115,10 +115,10 @@ public class ReporterAppender<E> extends OutputStreamAppender<E> {
      */
     @SuppressWarnings("unchecked")
     private static String concat(Object parts) {
-    	StringBuilder builder = new StringBuilder();
-    	for (String part : (List<String>) parts) {
-    		builder.append(part);
-    	}
+        StringBuilder builder = new StringBuilder();
+        for (String part : (List<String>) parts) {
+            builder.append(part);
+        }
         return builder.toString();
     }
 

--- a/src/main/java/com/github/sbabcoc/logback/testng/ReporterOutputStream.java
+++ b/src/main/java/com/github/sbabcoc/logback/testng/ReporterOutputStream.java
@@ -5,33 +5,33 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 public class ReporterOutputStream extends OutputStream {
-	
-	private boolean logToStdOut = false;
-	private ByteArrayOutputStream baos = new ByteArrayOutputStream();
-	
-	public void setLogToStdOut(boolean logToStdOut) {
-		this.logToStdOut = logToStdOut;
-	}
-	
-	@Override
-	public void write(int b) throws IOException {
-		baos.write(b);
-	}
-	
-	@Override
+
+    private boolean logToStdOut = false;
+    private ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+    public void setLogToStdOut(boolean logToStdOut) {
+        this.logToStdOut = logToStdOut;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        baos.write(b);
+    }
+
+    @Override
     public void write(byte b[], int off, int len) throws IOException {
-		baos.write(b, off, len);
-	}
-	
-	@Override
-	public void flush() {
-		ReporterAppender.log(baos.toString(), logToStdOut);
-		baos.reset();
-	}
-	
-	@Override
-	public void close() {
-		flush();
-	}
-	
+        baos.write(b, off, len);
+    }
+
+    @Override
+    public void flush() {
+        ReporterAppender.log(baos.toString(), logToStdOut);
+        baos.reset();
+    }
+
+    @Override
+    public void close() {
+        flush();
+    }
+
 }

--- a/src/main/java/com/github/sbabcoc/logback/testng/ReporterOutputStream.java
+++ b/src/main/java/com/github/sbabcoc/logback/testng/ReporterOutputStream.java
@@ -4,8 +4,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import org.testng.Reporter;
-
 public class ReporterOutputStream extends OutputStream {
 	
 	private boolean logToStdOut = false;
@@ -27,7 +25,7 @@ public class ReporterOutputStream extends OutputStream {
 	
 	@Override
 	public void flush() {
-		Reporter.log(baos.toString(), logToStdOut);
+		ReporterAppender.log(baos.toString(), logToStdOut);
 		baos.reset();
 	}
 	

--- a/src/test/java/com/github/sbabcoc/logback/testng/ReporterAppenderTest.java
+++ b/src/test/java/com/github/sbabcoc/logback/testng/ReporterAppenderTest.java
@@ -16,18 +16,18 @@ import ch.qos.logback.core.layout.DummyLayout;
 
 public class ReporterAppenderTest extends AbstractAppenderTest<Object> {
 
-	@Override
-	protected Appender<Object> getAppender() {
-		return new ReporterAppender<Object>();
-	}
+    @Override
+    protected Appender<Object> getAppender() {
+        return new ReporterAppender<Object>();
+    }
 
-	@Override
-	protected Appender<Object> getConfiguredAppender() {
+    @Override
+    protected Appender<Object> getConfiguredAppender() {
         ReporterAppender<Object> ra = new ReporterAppender<Object>();
         ra.setEncoder(new NopEncoder<Object>());
         ra.start();
         return ra;
-	}
+    }
 
     @Test
     public void smoke() {
@@ -73,23 +73,23 @@ public class ReporterAppenderTest extends AbstractAppenderTest<Object> {
         ra.doAppend(new Object());
         assertEquals(new String(ra.toString().getBytes(), charset), DummyLayout.DUMMY);
     }
-    
+
     @Test
     @Override
     public void testNewAppender() {
-    	super.testNewAppender();
+        super.testNewAppender();
     }
-    
+
     @Test
     @Override
     public void testConfiguredAppender() {
-    	super.testConfiguredAppender();
+        super.testConfiguredAppender();
     }
-    
+
     @Test
     @Override
     public void testNoStart() {
-    	super.testNoStart();
+        super.testNoStart();
     }
-    
+
 }


### PR DESCRIPTION
Explicit references to TestNG classes would trigger version collisions in some scenarios. This set of revisions replaces direct references to TestNG classes and methods with equivalent code implemented with the Java reflection API.